### PR TITLE
Add consistent sidebars to remaining pages and per-test runtime output

### DIFF
--- a/src/takeout_rater/ui/templates/base.html
+++ b/src/takeout_rater/ui/templates/base.html
@@ -120,7 +120,20 @@
     })();
   </script>
   <main class="{% block main_class %}{% endblock %}">
-    {% block content %}{% endblock %}
+    <div class="{% block page_layout_class %}sidebar-layout{% endblock %}">
+      {% block page_sidebar %}
+      <aside class="app-sidebar">
+        <div class="sidebar-section-title">Navigation</div>
+        <p class="sidebar-note">Use the top navigation bar to move between library tools.</p>
+        <div class="sidebar-divider"></div>
+        <div class="sidebar-section-title">Page options</div>
+        <p class="sidebar-note">This page does not expose extra sidebar controls yet.</p>
+      </aside>
+      {% endblock %}
+      <div class="{% block page_main_class %}sidebar-main{% endblock %}">
+        {% block content %}{% endblock %}
+      </div>
+    </div>
   </main>
 </body>
 </html>

--- a/src/takeout_rater/ui/templates/browse.html
+++ b/src/takeout_rater/ui/templates/browse.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 
 {% block title %}Browse – takeout-rater{% endblock %}
+{% block page_layout_class %}{% endblock %}
+{% block page_main_class %}{% endblock %}
+{% block page_sidebar %}{% endblock %}
 
 {% block head %}
 <style>

--- a/src/takeout_rater/ui/templates/scoring.html
+++ b/src/takeout_rater/ui/templates/scoring.html
@@ -247,6 +247,53 @@
 </style>
 {% endblock %}
 
+{% block page_sidebar %}
+<aside class="app-sidebar">
+  <div class="sidebar-section-title">Scorer settings</div>
+  <p class="sidebar-note">
+    Settings below affect scorer throughput, CLIP execution, and model source selection.
+  </p>
+
+  <div class="sidebar-divider"></div>
+  <div class="sidebar-section-title">Saved config (Setup page)</div>
+  <div class="sidebar-radio-group">
+    <label class="sidebar-radio">
+      <input type="radio" checked disabled>
+      <span>CLIP accelerator<small><code>performance.clip_accelerator</code> (auto / onnx / torch / tensorrt)</small></span>
+    </label>
+    <label class="sidebar-radio">
+      <input type="radio" checked disabled>
+      <span>CLIP batch size<small><code>performance.clip_batch_size</code> (64 / 96 / 128 / 160)</small></span>
+    </label>
+    <label class="sidebar-radio">
+      <input type="radio" checked disabled>
+      <span>Torch fp16<small><code>performance.clip_fp16</code> (enabled / disabled)</small></span>
+    </label>
+  </div>
+
+  <div class="sidebar-divider"></div>
+  <div class="sidebar-section-title">Environment variables</div>
+  <div class="sidebar-radio-group">
+    <label class="sidebar-radio">
+      <input type="radio" checked disabled>
+      <span><code>TAKEOUT_RATER_SCORE_BATCH_SIZE</code><small>Override scorer batch size used by scoring jobs.</small></span>
+    </label>
+    <label class="sidebar-radio">
+      <input type="radio" checked disabled>
+      <span><code>TAKEOUT_RATER_AESTHETIC_REPO</code><small>Override Hugging Face repo used by the LAION aesthetic scorer.</small></span>
+    </label>
+    <label class="sidebar-radio">
+      <input type="radio" checked disabled>
+      <span><code>TAKEOUT_RATER_ORT_VERBOSE</code><small>Enable/disable verbose ONNX Runtime logging for CLIP scorers.</small></span>
+    </label>
+    <label class="sidebar-radio">
+      <input type="radio" checked disabled>
+      <span><code>TAKEOUT_RATER_ORT_VERBOSITY</code><small>Set ONNX Runtime log verbosity level when verbose logging is enabled.</small></span>
+    </label>
+  </div>
+</aside>
+{% endblock %}
+
 {% block content %}
 <div class="scoring-page">
   <h1>🎯 Scoring</h1>

--- a/src/takeout_rater/ui/templates/setup.html
+++ b/src/takeout_rater/ui/templates/setup.html
@@ -3,6 +3,9 @@
 {% block title %}Setup – takeout-rater{% endblock %}
 
 {% block main_class %}setup-shell{% endblock %}
+{% block page_layout_class %}{% endblock %}
+{% block page_main_class %}{% endblock %}
+{% block page_sidebar %}{% endblock %}
 
 {% block head %}
 <style>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ import pytest
 
 from takeout_rater.scoring.scorers import clip_backbone
 
-
 _TEST_TOTAL_DURATIONS: defaultdict[str, float] = defaultdict(float)
 _PYTEST_CONFIG: pytest.Config | None = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import os
+from collections import defaultdict
 from pathlib import Path
 
 import pytest
 
 from takeout_rater.scoring.scorers import clip_backbone
+
+
+_TEST_TOTAL_DURATIONS: defaultdict[str, float] = defaultdict(float)
+_PYTEST_CONFIG: pytest.Config | None = None
 
 
 @pytest.fixture(autouse=True)
@@ -49,3 +54,24 @@ if os.name == "nt":
         return _ORIGINAL_MKDIR(self, mode=mode, parents=parents, exist_ok=exist_ok)
 
     Path.mkdir = _mkdir_sandbox_safe  # type: ignore[method-assign]
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Print total runtime for each test case as soon as it finishes."""
+    _TEST_TOTAL_DURATIONS[report.nodeid] += report.duration
+    if report.when != "teardown":
+        return
+
+    if _PYTEST_CONFIG is None:
+        return
+    terminal_reporter = _PYTEST_CONFIG.pluginmanager.get_plugin("terminalreporter")
+    if terminal_reporter is not None:
+        terminal_reporter.write_line(
+            f"runtime {report.nodeid}: {_TEST_TOTAL_DURATIONS.pop(report.nodeid):.4f}s",
+        )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Capture pytest config so report hooks can access terminal reporter."""
+    global _PYTEST_CONFIG  # noqa: PLW0603
+    _PYTEST_CONFIG = config


### PR DESCRIPTION
### Motivation
- Ensure every UI page that extends `base.html` uses the same sidebar layout and styling so pages without a custom sidebar are not blank.
- Surface scorer-relevant configuration and environment variables in the Scoring UI so users can discover scorer settings.
- Emit per-test runtimes for every pytest test case (slow and non-slow) to make test durations visible in CI logs.

### Description
- Added a default sidebar shell to `src/takeout_rater/ui/templates/base.html` with overridable blocks `page_layout_class`, `page_sidebar`, and `page_main_class` so pages inherit a consistent sidebar layout by default.
- Updated `src/takeout_rater/ui/templates/browse.html` and `src/takeout_rater/ui/templates/setup.html` to explicitly override the new blocks so their existing custom sidebars remain unchanged.
- Added a Scoring-specific sidebar block to `src/takeout_rater/ui/templates/scoring.html` listing scorer configuration keys and environment variables such as `performance.clip_accelerator`, `performance.clip_batch_size`, `performance.clip_fp16`, `TAKEOUT_RATER_SCORE_BATCH_SIZE`, `TAKEOUT_RATER_AESTHETIC_REPO`, `TAKEOUT_RATER_ORT_VERBOSE`, and `TAKEOUT_RATER_ORT_VERBOSITY`.
- Implemented pytest hooks in `tests/conftest.py` that accumulate test durations and print a single runtime line per test at teardown using `pytest_runtest_logreport` and captured pytest config via `pytest_configure`.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/docs/tools/test_infer_takeout_sidecar_schema.py`, which passed (11 tests) and produced per-test runtime lines for each test case. (passed)
- Attempted `pytest -q tests/ui/test_web_ui.py tests/cli/test_cli.py` and `PYTHONPATH=src pytest -q tests/ui/test_web_ui.py tests/cli/test_cli.py`, which were interrupted by environment/import constraints in this container (module import / `datetime.UTC` compatibility), unrelated to the changes in this PR. (failed due to environment)
- Committed the changes after validating the targeted docs/tools test and confirming the new per-test runtime output was emitted. (commit recorded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ee6c7f64832da07b387202748eed)